### PR TITLE
SystemUI: Resolve faulty keyguard clock logs outputs

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardClockSwitch.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardClockSwitch.java
@@ -392,7 +392,8 @@ public class KeyguardClockSwitch extends RelativeLayout {
         }
         if (Build.IS_DEBUGGABLE) {
             // Log for debugging b/130888082 (sysui waking up, but clock not updating)
-            Log.d(TAG, "Updating clock: " + mClockView.getText());
+            Log.d(TAG, "Updating clock: " + mClockView.getText().toString()
+                    .replaceAll("[^\\x00-\\x7F]", ":"));
         }
     }
 


### PR DESCRIPTION
 * Enforce Android logs outputs against special chars, example:
    "KeyguardClockSwitch: Updating clock: 1057"

Change-Id: I2642eb50276a2e3d99af696f25ddc1eafbfc3b4e